### PR TITLE
fix deepseek coder tokenizer error

### DIFF
--- a/llms/deepseek-coder/deepseek_coder.py
+++ b/llms/deepseek-coder/deepseek_coder.py
@@ -248,7 +248,7 @@ def load_model(model_path: str):
         nn.QuantizedLinear.quantize_module(model, **quantization)
     model.update(tree_unflatten(list(weights.items())))
 
-    tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True, use_fast=False)
+    tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
     return model, tokenizer
 
 


### PR DESCRIPTION
Disabling the fast tokenizer results in an error when running the example.
https://huggingface.co/mlx-community/deepseek-coder-6.7b-instruct-4-bit/discussions/1